### PR TITLE
Fix index out of bounds

### DIFF
--- a/src/easy_sqlite3/bindings.nim
+++ b/src/easy_sqlite3/bindings.nim
@@ -528,7 +528,7 @@ proc getColumn*(st: ref Statement, idx: int, T: typedesc[string]): string =
   let p = sqlite3_column_text(st.raw, idx)
   let l = sqlite3_column_bytes(st.raw, idx)
   result = newString l
-  copyMem(addr result[0], p, l)
+  if l > 0: copyMem(addr result[0], p, l)
 
 proc getColumn*[T](st: ref Statement, idx: int, _: typedesc[Option[T]]): Option[T] =
   if st.getColumnType(idx) == dt_null:


### PR DESCRIPTION
There is an index out of bounds when calling an iterator and it tried to construct a string of length 0. It calls copyMem on it but it fails because it has length 0.

Exception is: index out of bounds, the container is empty
  src/easy_sqlite3/bindings.nim(532) getColumn