### PR TITLE
Add missing conversion for Option[T] types

### DIFF
--- a/src/easy_sqlite3/bindings.nim
+++ b/src/easy_sqlite3/bindings.nim
@@ -491,6 +491,12 @@ proc `[]=`*(st: ref Statement, idx: int, val: type(nil)) =
 proc `[]=`*(st: ref Statement, idx: int, val: string) =
   st.raw.sqliteCheck sqlite3_bind_text(st.raw, idx, val, int32 val.len, TransientDestructor)
 
+proc `[]=`*[T](st: ref Statement, idx: int, val: Option[T]) =
+  if val.is_none:
+    st.raw.sqliteCheck sqlite3_bind_null(st.raw, idx)
+  else:
+    st[idx] = val.get
+
 proc reset*(st: ref Statement) =
   st.raw.sqliteCheck sqlite3_reset(st.raw)
 
@@ -534,7 +540,7 @@ proc getColumn*[T](st: ref Statement, idx: int, _: typedesc[Option[T]]): Option[
   if st.getColumnType(idx) == dt_null:
     none(T)
   else:
-    st.getColumn(idx, T)
+    some(st.getColumn(idx, T))
 
 proc unpack*[T: tuple](st: ref Statement, _: typedesc[T]): T =
   var idx = 0

--- a/tests/test_option.nim
+++ b/tests/test_option.nim
@@ -1,0 +1,40 @@
+import std/unittest
+import std/options
+
+import easy_sqlite3
+
+proc returnOptionNone(): tuple[col: Option[int]] {.importdb: "SELECT NULL;".}
+proc returnOptionSome(): tuple[col: Option[int]] {.importdb: "SELECT 1;".}
+
+proc takeOption(col: Option[int]): tuple[val: int, is_null: bool] {.importdb: "SELECT COALESCE($col, 0), $col IS NULL".}
+
+iterator options(a: Option[int], b: Option[int], c: Option[int]): tuple[val: Option[int]] {.importdb: "VALUES ($a+1), ($b+1), ($c+1)".} = discard
+
+suite "option":
+  setup:
+    var db = initDatabase(":memory:")
+
+  test "return option none":
+    let col = db.returnOptionNone().col
+    check col.is_none()
+
+  test "return option some":
+    let col = db.returnOptionSome().col
+    check col.is_some()
+    check col.get == 1
+
+  test "take option none":
+    let res = db.takeOption(none(int))
+    check res.is_null
+    check res.val == 0
+
+  test "take option some":
+    let res = db.takeOption(some(1))
+    check not res.is_null
+    check res.val == 1
+
+  test "iterator options":
+    var res: seq[Option[int]] = @[]
+    for row in db.options(some(1), none(int), some(2)):
+      res.add(row.val)
+    check res == @[some(2), none(int), some(3)]


### PR DESCRIPTION
Option[T] types should be allowed in proc arguments and return value inside tuples to signify a NULL value.

It seems preliminary support was available for return types (getColumn) but it did not compile. No support was implemented for input arguments (from Nim to SQL).