### PR TITLE
Bind to user-provided `getColumn` overrides in query macros

### DIFF
--- a/src/easy_sqlite3/macros.nim
+++ b/src/easy_sqlite3/macros.nim
@@ -86,7 +86,7 @@ proc fillPar(ret, st_ident: NimNode): NimNode =
         nnkCall.newTree(
           nnkDotExpr.newTree(
             st_ident,
-            bindSym "getColumn"
+            ident "getColumn"
           ),
           newLit idx,
           nnkBracketExpr.newTree(newIdentNode("typedesc"),it[1])


### PR DESCRIPTION
For custom types. `bindSym` restricts `getColumn` defs to those provided by the library.
Replacing it with `ident` causes the macro to pick up any `getColumn` within scope.